### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/santapone/275cd44b-4a45-4978-92cf-c96f59c14bec/73ea5cf8-3ebb-4dba-8c57-95c3427ce42a/_apis/work/boardbadge/f2579203-5dc9-4a6c-8de6-57056d0bb37f)](https://dev.azure.com/santapone/275cd44b-4a45-4978-92cf-c96f59c14bec/_boards/board/t/73ea5cf8-3ebb-4dba-8c57-95c3427ce42a/Microsoft.RequirementCategory)
 # SantaPone Central
 
 ## What is SantaPone Central?


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#188](https://dev.azure.com/santapone/275cd44b-4a45-4978-92cf-c96f59c14bec/_workitems/edit/188). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.